### PR TITLE
feat(onRunComplete): Prepend timestamp when reporting spec results

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,11 @@ var SpecReporter = function (baseReporterDecorator, formatError, config) {
         .join('\n') + '\n');
 
     if (browsers.length >= 1 && !results.disconnected && !results.error) {
+      var currentTime = reporterCfg.showSpecTiming ? new Date().toLocaleString() + ' - ' : '';
       if (!results.failed) {
-        this.write(this.TOTAL_SUCCESS, results.success);
+        this.write(currentTime.yellow + this.TOTAL_SUCCESS, results.success);
       } else {
-        this.write(this.TOTAL_FAILED, results.failed, results.success);
+        this.write(currentTime.yellow + this.TOTAL_FAILED, results.failed, results.success);
         if (!this.suppressErrorSummary) {
           this.logFinalErrors(this.failures);
         }


### PR DESCRIPTION
Motivation: When running test suites with `watch` functionality supported by Karma/Webpack it can be tricky to differentiate between runs, because the output gets appended to the console without any real delimiter between rebuilds/re-runs. So I added a timestamp when printing the overall results to make it easy to quickly differentiate between runs. 

Also, I kept this timestamp behind the configuration option: `showSpecTiming`.